### PR TITLE
search log: fix log rotate file prefix bug

### DIFF
--- a/search_log.go
+++ b/search_log.go
@@ -49,6 +49,8 @@ func resolveFiles(logFilePath string, beginTime, endTime int64) ([]logFile, erro
 	var logFiles []logFile
 	var skipFiles []*os.File
 	logDir := filepath.Dir(logFilePath)
+	ext := filepath.Ext(logFilePath)
+	filePrefix := logFilePath[:len(logFilePath)-len(ext)]
 	err := filepath.Walk(logDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -57,7 +59,7 @@ func resolveFiles(logFilePath string, beginTime, endTime int64) ([]logFile, erro
 			return nil
 		}
 		// All rotated log files have the same prefix with the original file
-		if !strings.HasPrefix(path, logFilePath) {
+		if !strings.HasPrefix(path, filePrefix) {
 			return nil
 		}
 		// If we cannot open the file, we skip to search the file instead of returning

--- a/search_log.go
+++ b/search_log.go
@@ -58,8 +58,11 @@ func resolveFiles(logFilePath string, beginTime, endTime int64) ([]logFile, erro
 		if info.IsDir() {
 			return nil
 		}
-		// All rotated log files have the same prefix with the original file
+		// All rotated log files have the same prefix and extension with the original file
 		if !strings.HasPrefix(path, filePrefix) {
+			return nil
+		}
+		if !strings.HasSuffix(path, ext) {
 			return nil
 		}
 		// If we cannot open the file, we skip to search the file instead of returning

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -81,19 +81,19 @@ func (s *searchLogSuite) TestResoveFiles(c *C) {
 	})
 
 	// single line file
-	s.writeTmpFile(c, "tidb.log.1", []string{
+	s.writeTmpFile(c, "tidb-1.log", []string{
 		`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
 	// two lines file
-	s.writeTmpFile(c, "tidb.log.2", []string{
+	s.writeTmpFile(c, "tidb-2.log", []string{
 		`[2019/08/26 06:21:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:21:15.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
 	// empty file
-	s.writeTmpFile(c, "tidb.log.3", []string{``})
-	s.writeTmpFile(c, "tidb.log.4", []string{
+	s.writeTmpFile(c, "tidb-3.log", []string{``})
+	s.writeTmpFile(c, "tidb-4.log", []string{
 		`[2019/08/26 06:22:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:15.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
@@ -213,26 +213,26 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 	})
 
 	// single line file
-	s.writeTmpFile(c, "rpc.tidb.log.1", []string{
+	s.writeTmpFile(c, "rpc.tidb-1.log", []string{
 		`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
 	// two lines file
-	s.writeTmpFile(c, "rpc.tidb.log.2", []string{
+	s.writeTmpFile(c, "rpc.tidb-2.log", []string{
 		`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:21:15.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
 	// empty file
-	s.writeTmpFile(c, "rpc.tidb.log.3", []string{``})
-	s.writeTmpFile(c, "rpc.tidb.log.4", []string{
+	s.writeTmpFile(c, "rpc.tidb-3.log", []string{``})
+	s.writeTmpFile(c, "rpc.tidb-4.log", []string{
 		`[2019/08/26 06:22:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 	})
-	s.writeTmpFile(c, "rpc.tidb.log.5", []string{
+	s.writeTmpFile(c, "rpc.tidb-5.log", []string{
 		`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 		`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
 	})


### PR DESCRIPTION
```shell
▶ ll tidb.log tidb-2019-12-24T21-12-15.148.log
-rw-r--r--  1 cs  staff   9.2G Dec 24 21:12 tidb-2019-12-24T21-12-15.148.log
-rw-r--r--  1 cs  staff    48M Dec 24 21:30 tidb.log
```
Check the rotate log file prefix should not contail the file name extension.