### PR TITLE
fix cpu physical cores bug

### DIFF
--- a/hardware_info.go
+++ b/hardware_info.go
@@ -17,12 +17,16 @@ func getHardwareInfo() []*pb.ServerInfoItem {
 	// cpu
 	infos, err := cpu.Info()
 	if err == nil && len(infos) > 0 {
+		physicalCores,err := cpu.Counts(false)
+		if err != nil {
+			physicalCores = int(infos[0].Cores)
+		}
 		results = append(results, &pb.ServerInfoItem{
 			Tp:   "cpu",
 			Name: "cpu",
 			Pairs: []*pb.ServerInfoPair{
 				{Key: "cpu-logical-cores", Value: fmt.Sprintf("%d", runtime.NumCPU())},
-				{Key: "cpu-physical-cores", Value: fmt.Sprintf("%d", infos[0].Cores)},
+				{Key: "cpu-physical-cores", Value: fmt.Sprintf("%d", physicalCores)},
 				{Key: "cpu-frequency", Value: fmt.Sprintf("%.2fMHz", infos[0].Mhz)},
 				{Key: "cache", Value: fmt.Sprintf("%d", infos[0].CacheSize)},
 			},


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

```sql
information_schema> SELECT instance,type,VALUE FROM information_schema.CLUSTER_HARDWARE WHERE device_type='cpu' and name = 'cpu-physical-cores' group by instance,type,VALUE;
+-------------------+------+-------+
| instance          | type | VALUE |
+-------------------+------+-------+
| 0.0.0.0:10089     | tidb | 1     |
| 172.16.5.40:23150 | tikv | 20    |
| 0.0.0.0:24799     | pd   | 1     |
+-------------------+------+-------+
```

TIDB, TIKV are in same server.

