### PR TITLE
hardware info: keep disk device name same as tikv

### DIFF
--- a/hardware_info.go
+++ b/hardware_info.go
@@ -49,7 +49,7 @@ func getHardwareInfo() []*pb.ServerInfoItem {
 	parts, err := disk.Partitions(true)
 	if err == nil && len(parts) > 0 {
 		for _, p := range parts {
-			if !strings.HasPrefix(p.Device, "/dev") {
+			if !strings.HasPrefix(p.Device, "/dev/") {
 				continue
 			}
 			usage, err := disk.Usage(p.Mountpoint)
@@ -58,7 +58,7 @@ func getHardwareInfo() []*pb.ServerInfoItem {
 			}
 			results = append(results, &pb.ServerInfoItem{
 				Tp:   "disk",
-				Name: p.Device[4:],
+				Name: p.Device[5:],
 				Pairs: []*pb.ServerInfoPair{
 					{Key: "fstype", Value: p.Fstype},
 					{Key: "opts", Value: p.Opts},

--- a/hardware_info.go
+++ b/hardware_info.go
@@ -17,7 +17,7 @@ func getHardwareInfo() []*pb.ServerInfoItem {
 	// cpu
 	infos, err := cpu.Info()
 	if err == nil && len(infos) > 0 {
-		physicalCores,err := cpu.Counts(false)
+		physicalCores, err := cpu.Counts(false)
 		if err != nil {
 			physicalCores = int(infos[0].Cores)
 		}
@@ -49,13 +49,16 @@ func getHardwareInfo() []*pb.ServerInfoItem {
 	parts, err := disk.Partitions(true)
 	if err == nil && len(parts) > 0 {
 		for _, p := range parts {
+			if !strings.HasPrefix(p.Device, "/dev") {
+				continue
+			}
 			usage, err := disk.Usage(p.Mountpoint)
 			if err != nil {
 				continue
 			}
 			results = append(results, &pb.ServerInfoItem{
 				Tp:   "disk",
-				Name: p.Device,
+				Name: p.Device[4:],
 				Pairs: []*pb.ServerInfoPair{
 					{Key: "fstype", Value: p.Fstype},
 					{Key: "opts", Value: p.Opts},


### PR DESCRIPTION
before
```sql
mysql>select * from `CLUSTER_HARDWARE` where device_type="disk" and name='path' and type='tidb';
+------+-------------------+-------------+--------------+------+---------------------------------+
| TYPE | INSTANCE          | DEVICE_TYPE | DEVICE_NAME  | NAME | VALUE                           |
+------+-------------------+-------------+--------------+------+---------------------------------+
| tidb | 172.16.5.40:10089 | disk        | /dev/nvme0n1 | path | /data3                          |
| tidb | 172.16.5.40:10089 | disk        | /dev/sda1    | path | /boot                           |
| tidb | 172.16.5.40:10089 | disk        | /dev/sda3    | path | /                               |
| tidb | 172.16.5.40:10089 | disk        | binfmt_misc  | path | /proc/sys/fs/binfmt_misc        |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/hugetlb          |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/devices          |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/cpuset           |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/memory           |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/blkio            |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/systemd          |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/freezer          |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/pids             |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/cpu,cpuacct      |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/perf_event       |
| tidb | 172.16.5.40:10089 | disk        | cgroup       | path | /sys/fs/cgroup/net_cls,net_prio |
| tidb | 172.16.5.40:10089 | disk        | configfs     | path | /sys/kernel/config              |
| tidb | 172.16.5.40:10089 | disk        | debugfs      | path | /sys/kernel/debug               |
| tidb | 172.16.5.40:10089 | disk        | devpts       | path | /dev/pts                        |
| tidb | 172.16.5.40:10089 | disk        | devtmpfs     | path | /dev                            |
| tidb | 172.16.5.40:10089 | disk        | hugetlbfs    | path | /dev/hugepages                  |
| tidb | 172.16.5.40:10089 | disk        | mqueue       | path | /dev/mqueue                     |
| tidb | 172.16.5.40:10089 | disk        | proc         | path | /proc                           |
| tidb | 172.16.5.40:10089 | disk        | pstore       | path | /sys/fs/pstore                  |
| tidb | 172.16.5.40:10089 | disk        | securityfs   | path | /sys/kernel/security            |
| tidb | 172.16.5.40:10089 | disk        | sysfs        | path | /sys                            |
| tidb | 172.16.5.40:10089 | disk        | systemd-1    | path | /proc/sys/fs/binfmt_misc        |
| tidb | 172.16.5.40:10089 | disk        | tmpfs        | path | /sys/fs/cgroup                  |
| tidb | 172.16.5.40:10089 | disk        | tmpfs        | path | /dev/shm                        |
| tidb | 172.16.5.40:10089 | disk        | tmpfs        | path | /run                            |
| tidb | 172.16.5.40:10089 | disk        | tmpfs        | path | /run/user/0                     |
| tidb | 172.16.5.40:10089 | disk        | tmpfs        | path | /run/user/1000                  |
```
This PR

```sql
mysql>select * from `CLUSTER_HARDWARE` where device_type="disk" and name='path' and type='tidb';
+------+-------------------+-------------+-------------+------+--------+
| TYPE | INSTANCE          | DEVICE_TYPE | DEVICE_NAME | NAME | VALUE  |
+------+-------------------+-------------+-------------+------+--------+
| tidb | 172.16.5.40:10089 | disk        | nvme0n1     | path | /data3 |
| tidb | 172.16.5.40:10089 | disk        | sda1        | path | /boot  |
| tidb | 172.16.5.40:10089 | disk        | sda3        | path | /      |
+------+-------------------+-------------+-------------+------+--------+
```