### PR TITLE
cluster_hardware: fix free-percent and used-percent

### DIFF
--- a/hardware_info.go
+++ b/hardware_info.go
@@ -66,8 +66,8 @@ func getHardwareInfo() []*pb.ServerInfoItem {
 					{Key: "total", Value: fmt.Sprintf("%d", usage.Total)},
 					{Key: "free", Value: fmt.Sprintf("%d", usage.Free)},
 					{Key: "used", Value: fmt.Sprintf("%d", usage.Used)},
-					{Key: "free-percent", Value: fmt.Sprintf("%.2f", 1-usage.UsedPercent)},
-					{Key: "used-percent", Value: fmt.Sprintf("%.2f", usage.UsedPercent)},
+					{Key: "free-percent", Value: fmt.Sprintf("%.2f", (100-usage.UsedPercent)/100.00)},
+					{Key: "used-percent", Value: fmt.Sprintf("%.2f", usage.UsedPercent/100.00)},
 				},
 			})
 		}


### PR DESCRIPTION
before: 
```
mysql root@127.0.0.1:INFORMATION_SCHEMA> select * from `CLUSTER_HARDWARE` where `NAME` in ('free-percent','used-percent') and `DEVICE_NAME` = 'sda1'
+------+-----------------+-------------+-------------+--------------+--------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME         | VALUE  |
+------+-----------------+-------------+-------------+--------------+--------+
| tidb | 0.0.0.0:4000    | disk        | sda1        | free-percent | -48.29 |
| tidb | 0.0.0.0:4000    | disk        | sda1        | used-percent | 49.29  |
| pd   | 127.0.0.1:2379  | disk        | sda1        | free-percent | -48.29 |
| pd   | 127.0.0.1:2379  | disk        | sda1        | used-percent | 49.29  |
| tikv | 127.0.0.1:20160 | disk        | sda1        | free-percent | 0.48   |
| tikv | 127.0.0.1:20160 | disk        | sda1        | used-percent | 0.48   |
+------+-----------------+-------------+-------------+--------------+--------+
6 rows in set

```

this pr : when use this pr's version in TiDB
```
mysql root@127.0.0.1:INFORMATION_SCHEMA> select * from `CLUSTER_HARDWARE` where `NAME` in ('free-percent','used-percent') and `DEVICE_NAME` = 'sda1'
+------+-----------------+-------------+-------------+--------------+--------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME         | VALUE  |
+------+-----------------+-------------+-------------+--------------+--------+
| tidb | 0.0.0.0:4000    | disk        | sda1        | free-percent | 0.51   |
| tidb | 0.0.0.0:4000    | disk        | sda1        | used-percent | 0.49   |
| pd   | 127.0.0.1:2379  | disk        | sda1        | free-percent | -48.29 |
| pd   | 127.0.0.1:2379  | disk        | sda1        | used-percent | 49.29  |
| tikv | 127.0.0.1:20160 | disk        | sda1        | free-percent | 0.48   |
| tikv | 127.0.0.1:20160 | disk        | sda1        | used-percent | 0.48   |
+------+-----------------+-------------+-------------+--------------+--------+
6 rows in set


```