### PR TITLE
refine cpu load usage info

### DIFF
--- a/load_info.go
+++ b/load_info.go
@@ -39,28 +39,35 @@ func getCpuLoad() []*pb.ServerInfoItem {
 			},
 		})
 	}
-	times, err := cpu.Times(true)
-	if err == nil && len(times) > 0 {
-		for _, t := range times {
-			item := &pb.ServerInfoItem{
-				Tp:   "cpu",
-				Name: t.CPU,
-				Pairs: []*pb.ServerInfoPair{
-					{Key: "user", Value: fmt.Sprintf("%.2f", t.User)},
-					{Key: "system", Value: fmt.Sprintf("%.2f", t.System)},
-					{Key: "idle", Value: fmt.Sprintf("%.2f", t.Idle)},
-					{Key: "nice", Value: fmt.Sprintf("%.2f", t.Nice)},
-					{Key: "iowait", Value: fmt.Sprintf("%.2f", t.Iowait)},
-					{Key: "irq", Value: fmt.Sprintf("%.2f", t.Irq)},
-					{Key: "softirq", Value: fmt.Sprintf("%.2f", t.Softirq)},
-					{Key: "steal", Value: fmt.Sprintf("%.2f", t.Steal)},
-					{Key: "guest", Value: fmt.Sprintf("%.2f", t.Guest)},
-					{Key: "guest_nice", Value: fmt.Sprintf("%.2f", t.GuestNice)},
-				},
-			}
-			results = append(results, item)
-		}
+	t1s, err := cpu.Times(false)
+	if err != nil {
+		return results
 	}
+	time.Sleep(time.Second)
+	t2s, err := cpu.Times(false)
+	if err != nil || len(t1s) != 1 || len(t2s) != 1 {
+		return results
+	}
+	t1 := t1s[0]
+	t2 := t2s[0]
+	total := t2.Total() - t1.Total()
+	item := &pb.ServerInfoItem{
+		Tp:   "cpu",
+		Name: "usage",
+		Pairs: []*pb.ServerInfoPair{
+			{Key: "user", Value: fmt.Sprintf("%.2f", (t2.User-t1.User)/total)},
+			{Key: "system", Value: fmt.Sprintf("%.2f", (t2.System-t1.System)/total)},
+			{Key: "idle", Value: fmt.Sprintf("%.2f", (t2.Idle-t1.Idle)/total)},
+			{Key: "nice", Value: fmt.Sprintf("%.2f", (t2.Nice-t1.Nice)/total)},
+			{Key: "iowait", Value: fmt.Sprintf("%.2f", (t2.Iowait-t1.Iowait)/total)},
+			{Key: "irq", Value: fmt.Sprintf("%.2f", (t2.Irq-t1.Irq)/total)},
+			{Key: "softirq", Value: fmt.Sprintf("%.2f", (t2.Softirq-t1.Softirq)/total)},
+			{Key: "steal", Value: fmt.Sprintf("%.2f", (t2.Steal-t1.Steal)/total)},
+			{Key: "guest", Value: fmt.Sprintf("%.2f", (t2.Guest-t1.Guest)/total)},
+			{Key: "guest_nice", Value: fmt.Sprintf("%.2f", (t2.GuestNice-t1.GuestNice)/total)},
+		},
+	}
+	results = append(results, item)
 	return results
 }
 


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

Before

```sql
select * from `CLUSTER_LOAD` where device_type='cpu'
+------+-------------------+-------------+-------------+------------+-------------+
| TYPE | INSTANCE          | DEVICE_TYPE | DEVICE_NAME | NAME       | VALUE       |
+------+-------------------+-------------+-------------+------------+-------------+
| tidb | 172.16.5.40:4009  | cpu         | cpu         | load1      | 0.51        |
| tidb | 172.16.5.40:4009  | cpu         | cpu         | load5      | 0.57        |
| tidb | 172.16.5.40:4009  | cpu         | cpu         | load15     | 1.00        |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | user       | 1792917.64  |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | system     | 487548.58   |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | idle       | 21709484.36 |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | nice       | 1592.56     |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | iowait     | 37874.43    |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | irq        | 0.00        |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | softirq    | 142449.47   |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | steal      | 0.00        |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | guest      | 0.00        |
| tidb | 172.16.5.40:4009  | cpu         | cpu0        | guest_nice | 0.00        |
| tidb | 172.16.5.40:4009  | cpu         | cpu1        | user       | 1687041.46  |
| tidb | 172.16.5.40:4009  | cpu         | cpu1        | system     | 453702.71   |
| tidb | 172.16.5.40:4009  | cpu         | cpu1        | idle       | 21911525.64 |
...
```

This PR: 

```sql
select * from `CLUSTER_LOAD` where device_type='cpu'
+------+-----------------+-------------+-------------+------------+--------------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME       | VALUE        |
+------+-----------------+-------------+-------------+------------+--------------+
| tidb | 127.0.0.1:4000  | cpu         | cpu         | load1      | 1.87         |
| tidb | 127.0.0.1:4000  | cpu         | cpu         | load5      | 3.30         |
| tidb | 127.0.0.1:4000  | cpu         | cpu         | load15     | 3.50         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | user       | 0.03         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | system     | 0.03         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | idle       | 0.94         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | nice       | 0.00         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | iowait     | 0.00         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | irq        | 0.00         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | softirq    | 0.00         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | steal      | 0.00         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | guest      | 0.00         |
| tidb | 127.0.0.1:4000  | cpu         | usage       | guest_nice | 0.00         |
```