### PR TITLE
fix test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,6 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: "1.13.5"
-      - name: Lookup yarn cache
-        id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  release_packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.13.5"
+      - name: Lookup yarn cache
+        id: yarn_cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Test
+        run: make

--- a/service_test.go
+++ b/service_test.go
@@ -69,7 +69,7 @@ func (s *serviceSuite) TestRPCServerInfo(c *C) {
 	client := pb.NewDiagnosticsClient(conn)
 
 	// Contact the server and print out its response.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// Test for load info.


### PR DESCRIPTION
- 1 second to load server info is too short, always fails
- although 2 seconds can make test pass, prefer to increase larger

error logs when fails:

```
> make
Running in native mode.

----------------------------------------------------------------------
FAIL: service_test.go:63: serviceSuite.TestRPCServerInfo

service_test.go:77:
    c.Assert(err, IsNil)
... value *status.statusError = &status.statusError{Code:4, Message:"context deadline exceeded", Details:[]*any.Any(nil), XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0} ("rpc error: code = DeadlineExceeded desc = context deadline exceeded")

OOPS: 4 passed, 1 FAILED
--- FAIL: TestT (1.04s)
FAIL
coverage: 56.1% of statements
FAIL    github.com/pingcap/sysutil      3.373s
FAIL
make: *** [gotest] Error 1
```