### PR TITLE
add benchmark for readLastLine method

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -17,6 +17,7 @@ package sysutil
 var (
 	ParseLogItem   = parseLogItem
 	ReadLine       = readLine
+	ReadLastLine   = readLastLine
 	ParseTimeStamp = parseTimeStamp
 	ResolveFiles   = resolveFiles
 )

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -523,7 +523,8 @@ func (s *searchLogSuite) BenchmarkReadLastLine(c *C) {
 		`[2019/08/26 06:22:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:15.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:22:16.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
-		`[2019/08/26 06:22:17.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
+		`[2019/08/26 06:22:17.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]` +
+			`[2019/08/26 06:22:17.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
 	// step 2. open it as read only mode
@@ -540,6 +541,10 @@ func (s *searchLogSuite) BenchmarkReadLastLine(c *C) {
 }
 
 // run benchmark by `go test -check.b`
-// result:
+// result for the last line of 76:
 // searchLogSuite.BenchmarkReadLastLine        10000            124423 ns/op
 // searchLogSuite.BenchmarkReadLastLine        10000            126135 ns/op
+//
+// result for the last line of 76*2=152:
+// searchLogSuite.BenchmarkReadLastLine        10000            247836 ns/op
+// searchLogSuite.BenchmarkReadLastLine        10000            251958 ns/op


### PR DESCRIPTION
This PR doesn't need to merge. It is just for comparing the benchmark result with the new implementation for readLastLine in PR #19 

Comparison:

```
Old way:
result for the last line of 76:
searchLogSuite.BenchmarkReadLastLine        10000            124423 ns/op
searchLogSuite.BenchmarkReadLastLine        10000            126135 ns/op

result for the last line of 76*2=152:
searchLogSuite.BenchmarkReadLastLine        10000            247836 ns/op
searchLogSuite.BenchmarkReadLastLine        10000            251958 ns/op

New way:
searchLogSuite.BenchmarkReadLastLines      1000000              1892 ns/op
searchLogSuite.BenchmarkReadLastLines      1000000              1920 ns/op
```

Conclusion: the new implementation is 65x (126135/1920) as fast as the old way when the last line is 76 long.





