### PR TITLE
Fix panic in invalid log

### DIFF
--- a/search_log.go
+++ b/search_log.go
@@ -250,7 +250,6 @@ func ParseLogLevel(s string) pb.LogLevel {
 // [2019/08/26 07:19:49.529 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."] ["Release Version"=v3.0.2]...
 // [2019/08/21 01:43:01.460 -04:00] [INFO] [util.go:60] [PD] [release-version=v3.0.2]
 // [2019/08/26 07:20:23.815 -04:00] [INFO] [mod.rs:28] ["Release Version:   3.0.2"]
-// other invalid log...
 func parseLogItem(s string) (*pb.LogMessage, error) {
 	timeLeftBound := strings.Index(s, "[")
 	timeRightBound := strings.Index(s, "]")

--- a/search_log.go
+++ b/search_log.go
@@ -256,7 +256,6 @@ func parseLogItem(s string) (*pb.LogMessage, error) {
 	if timeLeftBound == -1 || timeRightBound == -1 || timeLeftBound > timeRightBound {
 		return nil, fmt.Errorf("invalid log string: %s", s)
 	}
-
 	time, err := parseTimeStamp(s[timeLeftBound+1 : timeRightBound])
 	if err != nil {
 		return nil, err

--- a/search_log.go
+++ b/search_log.go
@@ -251,6 +251,7 @@ func ParseLogLevel(s string) pb.LogLevel {
 // [2019/08/21 01:43:01.460 -04:00] [INFO] [util.go:60] [PD] [release-version=v3.0.2]
 // [2019/08/26 07:20:23.815 -04:00] [INFO] [mod.rs:28] ["Release Version:   3.0.2"]
 func parseLogItem(s string) (*pb.LogMessage, error) {
+	fmt.Printf(s + "\n\n")
 	timeLeftBound := strings.Index(s, "[")
 	timeRightBound := strings.Index(s, "]")
 	if timeLeftBound == -1 || timeRightBound == -1 {

--- a/search_log.go
+++ b/search_log.go
@@ -250,13 +250,14 @@ func ParseLogLevel(s string) pb.LogLevel {
 // [2019/08/26 07:19:49.529 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."] ["Release Version"=v3.0.2]...
 // [2019/08/21 01:43:01.460 -04:00] [INFO] [util.go:60] [PD] [release-version=v3.0.2]
 // [2019/08/26 07:20:23.815 -04:00] [INFO] [mod.rs:28] ["Release Version:   3.0.2"]
+// other invalid log...
 func parseLogItem(s string) (*pb.LogMessage, error) {
-	fmt.Printf(s + "\n\n")
 	timeLeftBound := strings.Index(s, "[")
 	timeRightBound := strings.Index(s, "]")
-	if timeLeftBound == -1 || timeRightBound == -1 {
+	if timeLeftBound == -1 || timeRightBound == -1 || timeLeftBound > timeRightBound {
 		return nil, fmt.Errorf("invalid log string: %s", s)
 	}
+
 	time, err := parseTimeStamp(s[timeLeftBound+1 : timeRightBound])
 	if err != nil {
 		return nil, err

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -241,6 +241,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 	s.writeTmpFile(c, "rpc.tidb-5.log", []string{
 		`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 		`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
+		`[2020/08/04 15:41:52.688 +00:00] [ERROR] [misc.go:91] ["panic ..."] [r="\"assignment to entry in nil map\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1\n\t...`,
 	})
 
 	type timeRange struct{ start, end string }
@@ -294,6 +295,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:22:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 				`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
+				`[2020/08/04 15:41:52.688 +00:00] [ERROR] [misc.go:91] ["panic ..."] [r="\"assignment to entry in nil map\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1\n\t...`,
 			},
 		},
 		// 2
@@ -323,6 +325,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:22:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 				`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
+				`[2020/08/04 15:41:52.688 +00:00] [ERROR] [misc.go:91] ["panic ..."] [r="\"assignment to entry in nil map\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1\n\t...`,
 			},
 		},
 		// 4

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -213,7 +213,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 		`[2019/08/26 06:19:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-		`This is an invalid log blablabla`,
+		`This is an invalid log blablabla][`,
 		`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
@@ -241,7 +241,6 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 	s.writeTmpFile(c, "rpc.tidb-5.log", []string{
 		`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 		`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
-		`[2020/08/04 15:41:52.688 +00:00] [ERROR] [misc.go:91] ["panic ..."] [r="\"assignment to entry in nil map\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1\n\t...`,
 	})
 
 	type timeRange struct{ start, end string }
@@ -261,7 +260,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
@@ -282,7 +281,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
@@ -295,7 +294,6 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:22:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 				`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
-				`[2020/08/04 15:41:52.688 +00:00] [ERROR] [misc.go:91] ["panic ..."] [r="\"assignment to entry in nil map\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1\n\t...`,
 			},
 		},
 		// 2
@@ -306,7 +304,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 			},
 		},
@@ -325,7 +323,6 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:22:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test to TiDB."]`,
 				`[2019/08/27 06:23:14.011 -04:00] [INFO] [printer.go:41] ["partern test txn to TiDB."]`,
-				`[2020/08/04 15:41:52.688 +00:00] [ERROR] [misc.go:91] ["panic ..."] [r="\"assignment to entry in nil map\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1\n\t...`,
 			},
 		},
 		// 4
@@ -334,7 +331,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 			expect: []string{
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
@@ -359,7 +356,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 			},
 		},
 		// 7
@@ -369,7 +366,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 			},
 		},
 		// 8
@@ -378,7 +375,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 			levels: []pb.LogLevel{pb.LogLevel_Debug},
 			expect: []string{
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
-				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
 			},
 		},
 		// 9


### PR DESCRIPTION
```log
panic: runtime error: slice bounds out of range [2751:2748]

goroutine 546 [running]:
github.com/pingcap/sysutil.parseLogItem(0xc000a718eb, 0xaf9, 0x0, 0x684d1a0, 0xc0007b47f0)
        /Users/cs/code/goread/pkg/mod/github.com/crazycs520/sysutil@v0.0.0-20201009103826-40e6560dc0e5/search_log.go:260 +0x6f2
github.com/pingcap/sysutil.readLastValidLog(0xc0002b89c0, 0xa, 0xc000f17900, 0x0, 0x0)
        /Users/cs/code/goread/pkg/mod/github.com/crazycs520/sysutil@v0.0.0-20201009103826-40e6560dc0e5/search_log.go:151 +0x89
github.com/pingcap/sysutil.resolveFiles.func1(0xc000297ff0, 0x9, 0x68c6980, 0xc001183110, 0x0, 0x0, 0x9, 0xc000acf808)
        /Users/cs/code/goread/pkg/mod/github.com/crazycs520/sysutil@v0.0.0-20201009103826-40e6560dc0e5/search_log.go:83 +0x37f
path/filepath.walk(0xc000297ff0, 0x9, 0x68c6980, 0xc001183110, 0xc000acfa20, 0x0, 0x0)
        /usr/local/go/src/path/filepath/path.go:360 +0x425
path/filepath.walk(0x62d6855, 0x1, 0x68c6980, 0xc0005da340, 0xc000acfa20, 0x0, 0x62d6855)
        /usr/local/go/src/path/filepath/path.go:384 +0x2ff
path/filepath.Walk(0x62d6855, 0x1, 0xc000d88a20, 0x4, 0x40571ec)
        /usr/local/go/src/path/filepath/path.go:406 +0xff
github.com/pingcap/sysutil.resolveFiles(0x7ffeefbff43e, 0x8, 0x16f5caf7401, 0x1757f630fff, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/cs/code/goread/pkg/mod/github.com/crazycs520/sysutil@v0.0.0-20201009103826-40e6560dc0e5/search_log.go:54 +0x1bc
github.com/pingcap/sysutil.(*DiagnosticsServer).SearchLog(0xc000f7e940, 0xc0005f8150, 0x68c9200, 0xc0002be190, 0x0, 0x0)
        /Users/cs/code/goread/pkg/mod/github.com/crazycs520/sysutil@v0.0.0-20201009103826-40e6560dc0e5/service.go:45 +0xa4
github.com/pingcap/kvproto/pkg/diagnosticspb._Diagnostics_SearchLog_Handler(0x62ae060, 0xc001141c50, 0x68c6680, 0xc0005fe0c0, 0x84225f8, 0xc0013a8000)
        /Users/cs/code/goread/pkg/mod/github.com/pingcap/kvproto@v0.0.0-20200828054126-d677e6fd224a/pkg/diagnosticspb/diagnosticspb.pb.go:633 +0x109
google.golang.org/grpc.(*Server).processStreamingRPC(0xc001152600, 0x68d2740, 0xc001380180, 0xc0013a8000, 0xc001141ce0, 0x837ef80, 0x0, 0x0, 0x0)
        /Users/cs/code/goread/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1237 +0xcd1
google.golang.org/grpc.(*Server).handleStream(0xc001152600, 0x68d2740, 0xc001380180, 0xc0013a8000, 0x0)
        /Users/cs/code/goread/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1317 +0xcd6
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0005d4170, 0xc001152600, 0x68d2740, 0xc001380180, 0xc0013a8000)
        /Users/cs/code/goread/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:722 +0xa1
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/cs/code/goread/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:720 +0xa1
```