### PR TITLE
Add transparent hugepage enabled information

### DIFF
--- a/system_info.go
+++ b/system_info.go
@@ -32,7 +32,7 @@ func tryProcFs() []*pb.ServerInfoItem {
 		}
 		item.Pairs = append(item.Pairs, &pb.ServerInfoPair{
 			Key:   strings.ReplaceAll(strings.TrimPrefix(path, dir), "/", "."),
-			Value: strings.TrimSuffix(string(content), "\n"),
+			Value: strings.TrimSpace(string(content)),
 		})
 		return nil
 	})
@@ -141,7 +141,7 @@ func getTransparentHugepageEnabled() []*pb.ServerInfoItem {
 	}
 	item.Pairs = append(item.Pairs, &pb.ServerInfoPair{
 		Key:   "transparent_hugepage_enabled",
-		Value: strings.TrimSuffix(string(content), "\n"),
+		Value: strings.TrimSpace(string(content)),
 	})
 	return []*pb.ServerInfoItem{item}
 }

--- a/system_info.go
+++ b/system_info.go
@@ -32,7 +32,7 @@ func tryProcFs() []*pb.ServerInfoItem {
 		}
 		item.Pairs = append(item.Pairs, &pb.ServerInfoPair{
 			Key:   strings.ReplaceAll(strings.TrimPrefix(path, dir), "/", "."),
-			Value: string(content),
+			Value: strings.TrimSuffix(string(content), "\n"),
 		})
 		return nil
 	})
@@ -141,7 +141,7 @@ func getTransparentHugepageEnabled() []*pb.ServerInfoItem {
 	}
 	item.Pairs = append(item.Pairs, &pb.ServerInfoPair{
 		Key:   "transparent_hugepage_enabled",
-		Value: string(content),
+		Value: strings.TrimSuffix(string(content), "\n"),
 	})
 	return []*pb.ServerInfoItem{item}
 }


### PR DESCRIPTION
related issue: https://github.com/pingcap/tidb/issues/19538

example:

```sql
information_schema> select * from `CLUSTER_SYSTEMINFO` where name = 'transparent_hugepage_enabled';
+------+------------------+-------------+-------------+------------------------------+------------------------+
| TYPE | INSTANCE         | SYSTEM_TYPE | SYSTEM_NAME | NAME                         | VALUE                  |
+------+------------------+-------------+-------------+------------------------------+------------------------+
| tidb | 172.16.5.40:4019 | system      | kernel      | transparent_hugepage_enabled | always madvise [never] |
+------+------------------+-------------+-------------+------------------------------+------------------------+

```