### PR TITLE
fix issue of query SearchLog is canceled but the service goroutine still running

### DIFF
--- a/search_log.go
+++ b/search_log.go
@@ -52,7 +52,6 @@ func resolveFiles(ctx context.Context, logFilePath string, beginTime, endTime in
 	logDir := filepath.Dir(logFilePath)
 	ext := filepath.Ext(logFilePath)
 	filePrefix := logFilePath[:len(logFilePath)-len(ext)]
-	fmt.Printf("prefix: %v, ext: %v --\n", filePrefix, ext)
 	err := filepath.Walk(logDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -108,8 +107,6 @@ func resolveFiles(ctx context.Context, logFilePath string, beginTime, endTime in
 		}
 		return nil
 	})
-
-	fmt.Printf("resolve log finish   %v--\n", time.Now())
 
 	defer func() {
 		for _, f := range skipFiles {

--- a/search_log.go
+++ b/search_log.go
@@ -338,7 +338,7 @@ func (iter *logIterator) close() {
 	}
 }
 
-func (iter *logIterator) next() (*pb.LogMessage, error) {
+func (iter *logIterator) next(ctx context.Context) (*pb.LogMessage, error) {
 	// initial state
 	if iter.reader == nil {
 		if len(iter.pending) == 0 {
@@ -349,6 +349,9 @@ func (iter *logIterator) next() (*pb.LogMessage, error) {
 
 nextLine:
 	for {
+		if isCtxDone(ctx) {
+			return nil, ctx.Err()
+		}
 		line, err := readLine(iter.reader)
 		// Switch to next log file
 		if err != nil && err == io.EOF {

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -580,7 +580,7 @@ func (s *searchLogSuite) TestReadAndAppendLogFile(c *C) {
 	i := 0
 	endCursor := filesize
 	for {
-		lines, readBytes := sysutil.ReadLastLines(file, endCursor)
+		lines, readBytes, _ := sysutil.ReadLastLines(context.Background(), file, endCursor)
 		// read out the file
 		if readBytes == 0 {
 			break
@@ -615,7 +615,7 @@ func (s *searchLogSuite) BenchmarkReadLastLines(c *C) {
 	// step 3. start to benchmark
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		sysutil.ReadLastLines(file, filesize)
+		sysutil.ReadLastLines(context.Background(), file, filesize)
 	}
 }
 

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -192,7 +192,7 @@ func (s *searchLogSuite) TestResoveFiles(c *C) {
 		c.Assert(err, IsNil)
 		endTime, err := sysutil.ParseTimeStamp(cas.search.end)
 		c.Assert(err, IsNil)
-		logFiles, err := sysutil.ResolveFiles(filepath.Join(s.tmpDir, "tidb.log"), beginTime, endTime)
+		logFiles, err := sysutil.ResolveFiles(context.Background(), filepath.Join(s.tmpDir, "tidb.log"), beginTime, endTime)
 		c.Assert(err, IsNil)
 		c.Assert(len(logFiles), Equals, len(cas.expect), Commentf("search range (index: %d): %+v", i, cas.search))
 

--- a/service.go
+++ b/service.go
@@ -42,7 +42,8 @@ func (d *DiagnosticsServer) SearchLog(req *pb.SearchLogRequest, stream pb.Diagno
 		endTime = math.MaxInt64
 	}
 
-	logFiles, err := resolveFiles(stream.Context(), d.logFile, beginTime, endTime)
+	ctx := stream.Context()
+	logFiles, err := resolveFiles(ctx, d.logFile, beginTime, endTime)
 	if err != nil {
 		return err
 	}
@@ -77,7 +78,7 @@ func (d *DiagnosticsServer) SearchLog(req *pb.SearchLogRequest, stream pb.Diagno
 		var messages []*pb.LogMessage
 		var drained bool
 		for i := 0; i < 1024; i++ {
-			item, err := iter.next()
+			item, err := iter.next(ctx)
 			if err == io.EOF {
 				drained = true
 				break

--- a/service.go
+++ b/service.go
@@ -42,7 +42,7 @@ func (d *DiagnosticsServer) SearchLog(req *pb.SearchLogRequest, stream pb.Diagno
 		endTime = math.MaxInt64
 	}
 
-	logFiles, err := resolveFiles(d.logFile, beginTime, endTime)
+	logFiles, err := resolveFiles(stream.Context(), d.logFile, beginTime, endTime)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The issue is, when the query of `SearchLog` is canceled, the `resolveFiles` function is still running since it doesn't check the `context.Done`.

![image](https://user-images.githubusercontent.com/26020263/100572177-d837e580-330f-11eb-832a-e1f44fa36559.png)

This PR do below 2 things:
* Add context check in `resolveFiles` function.
* Remove `filepath.Walk`, since it will traverse all files in depth, It is no needed, we can only traverse all files in the 1 depth.