### PR TITLE
optimize the readLastLines function for huge lines

### DIFF
--- a/search_log.go
+++ b/search_log.go
@@ -203,6 +203,8 @@ func readLine(reader *bufio.Reader) (string, error) {
 	return string(line), nil
 }
 
+const maxReadCacheSize = 1024 * 1024 * 16
+
 // Read lines from the end of a file
 // endCursor initial value should be the file size
 func readLastLines(ctx context.Context, file *os.File, endCursor int64) ([]string, int, error) {
@@ -219,6 +221,9 @@ func readLastLines(ctx context.Context, file *os.File, endCursor int64) ([]strin
 
 		// enlarge the read cache to avoid too many memory move.
 		size = size * 2
+		if size > maxReadCacheSize {
+			size = maxReadCacheSize
+		}
 		if cursor < size {
 			size = cursor
 		}

--- a/search_log.go
+++ b/search_log.go
@@ -182,6 +182,7 @@ func readLastLines(file *os.File, endCursor int64) ([]string, int) {
 	var lines []byte
 	var firstNonNewlinePos int
 	var cursor = endCursor
+	var size int64 = 256
 	for {
 		// stop if we are at the begining
 		// check it in the start to avoid read beyond the size
@@ -189,7 +190,8 @@ func readLastLines(file *os.File, endCursor int64) ([]string, int) {
 			break
 		}
 
-		var size int64 = 512
+		// enlarge the read cache to avoid too many memory move.
+		size = size * 2
 		if cursor < size {
 			size = cursor
 		}

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -619,6 +619,30 @@ func (s *searchLogSuite) BenchmarkReadLastLines(c *C) {
 	}
 }
 
+func (s *searchLogSuite) BenchmarkReadLastLinesOfHugeLine(c *C) {
+	// step 1. initial a huge line log file
+	hugeLine := make([]byte, 1024*1024*10)
+	for i := range hugeLine {
+		hugeLine[i] = 'a' + byte(i%26)
+	}
+	s.writeTmpFile(c, "tidb.log", []string{string(hugeLine)})
+
+	// step 2. open it as read only mode
+	path := filepath.Join(s.tmpDir, "tidb.log")
+	file, err := os.OpenFile(path, os.O_RDONLY, os.ModePerm)
+	c.Assert(err, IsNil, Commentf("open file %s failed", path))
+	defer file.Close()
+
+	stat, _ := file.Stat()
+	filesize := stat.Size()
+
+	// step 3. start to benchmark
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		sysutil.ReadLastLines(file, filesize)
+	}
+}
+
 // run benchmark by `go test -check.b`
 // result:
 // searchLogSuite.BenchmarkReadLastLines      1000000              2008 ns/op


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26020263/100572177-d837e580-330f-11eb-832a-e1f44fa36559.png)

When the last line is very huge, the `readLastLines` may be very slow.

Here is a benchmark when the last log line size is `10MB`:

```go
Before this PR:
searchLogSuite.BenchmarkReadLastLinesOfHugeLine          1        10227299446 ns/op

This PR:
searchLogSuite.BenchmarkReadLastLinesOfHugeLine        100          14824774 ns/op
```