### PR TITLE
fix panic in search invalid log 

### DIFF
--- a/search_log.go
+++ b/search_log.go
@@ -305,6 +305,9 @@ func parseLogItem(s string) (*pb.LogMessage, error) {
 	}
 	levelLeftBound := strings.Index(s[timeRightBound+1:], "[")
 	levelRightBound := strings.Index(s[timeRightBound+1:], "]")
+	if levelLeftBound == -1 || levelRightBound == -1 || levelLeftBound > levelRightBound {
+		return nil, fmt.Errorf("invalid log string: %s", s)
+	}
 	level := ParseLogLevel(s[timeRightBound+1+levelLeftBound+1 : timeRightBound+1+levelRightBound])
 	item := &pb.LogMessage{
 		Time:    time,

--- a/search_log_test.go
+++ b/search_log_test.go
@@ -214,6 +214,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 		`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 		`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 		`This is an invalid log blablabla][`,
+		`[2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 		`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 	})
 
@@ -261,6 +262,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
@@ -282,6 +284,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
@@ -305,6 +308,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 			},
 		},
@@ -332,6 +336,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 				`[2019/08/26 06:19:17.011 -04:00] [TRACE] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:20:14.011 -04:00] [INFO] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:21:14.011 -04:00] [WARN] [printer.go:41] ["Welcome to TiDB."]`,
@@ -357,6 +362,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 			},
 		},
 		// 7
@@ -367,6 +373,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 				`[2019/08/26 06:19:15.011 -04:00] [ERROR] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 			},
 		},
 		// 8
@@ -376,6 +383,7 @@ func (s *searchLogSuite) TestLogIterator(c *C) {
 			expect: []string{
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [printer.go:41] ["Welcome to TiDB."]`,
 				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] This is an invalid log blablabla][`,
+				`[2019/08/26 06:19:16.011 -04:00] [DEBUG] [2019/08/26 06:19:17.011 -04:00] ] [INFO] invalid log"]`,
 			},
 		},
 		// 9


### PR DESCRIPTION
Signed-off-by: crazycs <chen.two.cs@gmail.com>

```go
[2021/09/03 07:08:18.763 +00:00] [ERROR] [service.go:48] ["search log panic, runtime error: slice bounds out of range [34:31], stack is goroutine 50528758 [running]:
github.com/pingcap/sysutil.(*DiagnosticsServer).SearchLog.func1(0xc004f5bc48)
	/nfs/cache/mod/github.com/pingcap/sysutil@v0.0.0-20210730114356-fcd8a63f68c5/service.go:45 +0xa5
panic(0x3950140, 0xc000893668)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/pingcap/sysutil.parseLogItem(0xc0056047e0, 0x26, 0xc000610f88, 0x36ce000, 0xc006cea040)
	/nfs/cache/mod/github.com/pingcap/sysutil@v0.0.0-20210730114356-fcd8a63f68c5/search_log.go:308 +0x695
github.com/pingcap/sysutil.readLastValidLog(0x4088390, 0xc0157bc9f0, 0xc000610f88, 0xa, 0xc007df2f00, 0x0, 0x0)
	/nfs/cache/mod/github.com/pingcap/sysutil@v0.0.0-20210730114356-fcd8a63f68c5/search_log.go:178 +0x8f
github.com/pingcap/sysutil.resolveFiles.func1(0xc0150ae120, 0x19, 0x40a22a8, 0xc012b8e750, 0x19, 0x0)
	/nfs/cache/mod/github.com/pingcap/sysutil@v0.0.0-20210730114356-fcd8a63f68c5/search_log.go:89 +0x457
github.com/pingcap/sysutil.resolveFiles(0x4088390, 0xc0157bc9f0, 0x7ffd6dbcdedb, 0x19, 0x17baa7bb070, 0x17baa7c9ad0, 0x0, 0x0, 0x0, 0x0, ...)
	/nfs/cache/mod/github.com/pingcap/sysutil@v0.0.0-20210730114356-fcd8a63f68c5/search_log.go:113 +0x335
github.com/pingcap/sysutil.(*DiagnosticsServer).SearchLog(0xc00162d8d0, 0xc0040a4d90, 0x40a4578, 0xc00e583be0, 0x0, 0x0)
	/nfs/cache/mod/github.com/pingcap/sysutil@v0.0.0-20210730114356-fcd8a63f68c5/service.go:59 +0x126
github.com/pingcap/kvproto/pkg/diagnosticspb._Diagnostics_SearchLog_Handler(0x3b30660, 0xc001c1c5a0, 0x40a1c78, 0xc0151bd800, 0x5e2ff48, 0xc014d6a000)
	/nfs/cache/mod/github.com/pingcap/kvproto@v0.0.0-20210806074406-317f69fb54b4/pkg/diagnosticspb/diagnosticspb.pb.go:633 +0x113
google.golang.org/grpc.(*Server).processStreamingRPC(0xc0018f8680, 0x40b0d38, 0xc00e079c80, 0xc014d6a000, 0xc001c1c630, 0x5722d00, 0x0, 0x0, 0x0)
	/nfs/cache/mod/google.golang.org/grpc@v1.29.1/server.go:1329 +0xcd8
google.golang.org/grpc.(*Server).handleStream(0xc0018f8680, 0x40b0d38, 0xc00e079c80, 0xc014d6a000, 0x0)
	/nfs/cache/mod/google.golang.org/grpc@v1.29.1/server.go:1409 +0xc68
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc00f6b2170, 0xc0018f8680, 0x40b0d38, 0xc00e079c80, 0xc014d6a000)
	/nfs/cache/mod/google.golang.org/grpc@v1.29.1/server.go:746 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/nfs/cache/mod/google.golang.org/grpc@v1.29.1/server.go:744 +0xa5
"]

```